### PR TITLE
Set up REST API communication between retriever and orchestrator

### DIFF
--- a/orchestrator/Dockerfile
+++ b/orchestrator/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt \
+    apt-get update && apt-get install -y curl
+
+
+COPY main.py .
+
+EXPOSE 8000
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/orchestrator/k8s/deployment.yaml
+++ b/orchestrator/k8s/deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1  # API 버전 (Deployment를 정의할 때 사용하는 Kubernetes API 그룹)
+kind: Deployment  # 리소스 종류 (Deployment 객체 생성)
+metadata:
+  name: orchestrator-app  # Deployment의 이름 (fastapi-app이라는 이름으로 정의됨)
+spec:
+  # replicas: 2  # Pod을 2개 실행 (수평 확장을 위한 설정)
+  selector:
+    matchLabels:
+      app: orchestrator-app  # 이 레이블이 있는 Pod을 관리
+  template:
+    metadata:
+      labels:
+        app: orchestrator-app  # Pod에 붙일 레이블 (Service에서 Pod을 찾을 때 사용)
+    spec:
+      containers:
+      - name: orchestrator-app  # 컨테이너 이름
+        image: chowonseo/orchestrator:latest
+        # imagePullPolicy: IfNotPresent # 외부에서 pull 하지 않도록 (Docker registry 에서 찾는것을 방지)
+        ports:
+        - containerPort: 8000  # 컨테이너 내부에서 노출할 포트 (FastAPI 기본 포트)

--- a/orchestrator/k8s/service.yaml
+++ b/orchestrator/k8s/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1  # API 버전 (Service를 정의할 때 사용하는 Kubernetes API 그룹)
+kind: Service  # 리소스 종류 (Service 객체 생성)
+metadata:
+  name: orchestrator-service  # Service의 이름
+spec:
+  type: LoadBalancer  # 외부에서도 접근할 수 있도록 Load Balancer 생성
+  selector:
+    app: orchestrator-app  # 레이블이 fastapi-app인 Pod과 연결
+  ports:
+  - protocol: TCP  # 네트워크 프로토콜 (TCP 사용)
+    port: 8080  # 외부에서 접근할 수 있는 포트 (retriever = 80, orchestrator = 8080)
+    targetPort: 8000  # 내부 컨테이너에서 사용하는 포트 (FastAPI가 실행 중인 포트)

--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -1,0 +1,31 @@
+# orchestrator.py
+from fastapi import FastAPI
+from pydantic import BaseModel
+import requests
+
+app = FastAPI(title="RAG Orchestrator")
+
+# Retriever / Generator URL (Kubernetes Service 이름 기준)
+RETRIEVER_URL = "http://retriever-service:8000/query"
+# GENERATOR_URL = "http://generator-service:8000/generate"
+
+class QueryRequest(BaseModel):
+    query_text: str
+    top_k: int = 5
+
+class GeneratorResponse(BaseModel):
+    answer: str
+
+
+@app.get("/")
+def root():
+    return {"message": "Orchestrator is running"}
+
+@app.post("/query")
+def handle_query(req: QueryRequest):
+    # 1. Calls Retriever
+    retriever_payload = {"query_text": req.query_text, "top_k": req.top_k}
+    retriever_res = requests.post(RETRIEVER_URL, json=retriever_payload).json()
+    context_chunks = [r["document"] for r in retriever_res.get("results", [])]
+
+    return {"query": req.query_text, "results": retriever_res, "context_chunks": context_chunks}

--- a/orchestrator/requirements.txt
+++ b/orchestrator/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn[standard]
+requests
+pydantic


### PR DESCRIPTION
## 🧠 Summary
> Explain what this PR does.

## 🧩 Related Issues
Closes #5 

## 🧰 Changes
- [x] Feature / Improvement
- [ ] Bug Fix
- [ ] Refactor / Cleanup
- [ ] Documentation

## 🧪 Development Notes
> Use this section to help reviewers understand the implementation.  

Added an endpoint for orchestrator to receive query.
Through /query, it sends its request through POST method to retriever's /query.
The returned response will be aggregated with original query and will be sent to the generator


## 🔍 Testing
> Describe how you tested the change.
<img width="1721" height="219" alt="Screenshot 2025-11-19 at 6 59 07 PM" src="https://github.com/user-attachments/assets/5f67bdfc-acdd-4edb-a3c5-0c9cd0b311ff" />


Test environment: orchestrator pod's `bash`.
`curl -X POST "http://retriever-service/query"`

## 🚀 Deployment Notes
> Any special considerations for deployment 