### PR TITLE
FAISS -> pgvector migration

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -4,7 +4,7 @@
 # 볼륨: 아래 name을 두 compose에서 동일하게 두면 로컬/통합 테스트가 같은 DB 데이터 공유
 services:
   postgres:
-    image: postgres:15.1-alpine
+    image: pgvector/pgvector:pg15
     ports:
       - "5432:5432"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,7 @@ services:
       retries: 3
 
   postgres:
-    image: postgres:15.1-alpine
+    image: pgvector/pgvector:pg15
     ports:
       - "5432:5432"
     environment:

--- a/retriever/init_db.sql
+++ b/retriever/init_db.sql
@@ -1,3 +1,5 @@
+CREATE EXTENSION IF NOT EXISTS vector;
+
 CREATE TABLE documents (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     title TEXT NOT NULL,
@@ -6,8 +8,15 @@ CREATE TABLE documents (
     version INT NOT NULL DEFAULT 1,
     source_url TEXT,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    -- 384 dims for all-MiniLM-L6-v2; nullable until backfilled
+    embedding vector(384) 
 );
 
 CREATE INDEX idx_documents_domain ON documents (domain);
 CREATE INDEX idx_documents_title ON documents (title);
+
+-- HNSW index for cosine similarity search (<=> operator)
+CREATE INDEX idx_documents_embedding ON documents
+USING hnsw (embedding vector_cosine_ops)
+WITH (m = 16, ef_construction = 64);

--- a/retriever/main.py
+++ b/retriever/main.py
@@ -30,6 +30,18 @@ def root():
 def health():
     return {"status": "ok"}
 
+
+@app.post("/test-add-document")
+def test_add_document():
+    """add_document 로컬 테스트용: 샘플 문서 하나 넣고 id 반환"""
+    doc = retriever.add_document(
+        title="Test doc",
+        content="This is a test document for add_document.",
+        domain="overview",
+    )
+    return {"message": "ok", "id": doc.id, "title": doc.title}
+
+
 @app.get("/load_data")
 def load_data():
     retriever._load_data()

--- a/retriever/main.py
+++ b/retriever/main.py
@@ -11,6 +11,11 @@ class QueryRequest(BaseModel):
     query_text: str
     top_k: int = 5
 
+class AddDocumentRequest(BaseModel):
+    title: str
+    content: str
+    domain: str
+    source_url: str | None = None
 
 app = FastAPI()
 
@@ -30,23 +35,16 @@ def root():
 def health():
     return {"status": "ok"}
 
-
-@app.post("/test-add-document")
-def test_add_document():
-    """add_document 로컬 테스트용: 샘플 문서 하나 넣고 id 반환"""
+@app.post("/add-document")
+def add_document(req: AddDocumentRequest):
+    """Add a document to the repository."""
     doc = retriever.add_document(
-        title="Test doc",
-        content="This is a test document for add_document.",
-        domain="overview",
+        title=req.title,
+        content=req.content,
+        domain=req.domain,
+        source_url=req.source_url,
     )
     return {"message": "ok", "id": doc.id, "title": doc.title}
-
-
-@app.get("/load_data")
-def load_data():
-    retriever._load_data()
-    retriever._embed_documents()
-    return {"message": "Data loaded successfully.", "num_documents": len(retriever.documents)}
 
 @app.post("/query")
 def query(req: QueryRequest):

--- a/retriever/models.py
+++ b/retriever/models.py
@@ -1,12 +1,18 @@
 from datetime import datetime
+from typing import List
 
 from sqlalchemy import String, Text, Integer, DateTime, func
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+from pgvector.sqlalchemy import Vector
 
 
 class Base(DeclarativeBase):
     pass
+
+
+# Embedding dimension for all-MiniLM-L6-v2
+EMBEDDING_DIM = 384
 
 
 class Document(Base):
@@ -20,3 +26,4 @@ class Document(Base):
     source_url: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    embedding: Mapped[List[float] | None] = mapped_column(Vector(EMBEDDING_DIM), nullable=True)

--- a/retriever/models.py
+++ b/retriever/models.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import List
 
-from sqlalchemy import String, Text, Integer, DateTime, func
+from sqlalchemy import String, Text, Integer, DateTime, func, text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 from pgvector.sqlalchemy import Vector
@@ -18,7 +18,7 @@ EMBEDDING_DIM = 384
 class Document(Base):
     __tablename__ = "documents"
 
-    id: Mapped[str] = mapped_column(UUID(as_uuid=False), primary_key=True)
+    id: Mapped[str] = mapped_column(UUID(as_uuid=False), primary_key=True, server_default=text("gen_random_uuid()"))
     title: Mapped[str] = mapped_column(Text, nullable=False)
     content: Mapped[str] = mapped_column(Text, nullable=False)
     domain: Mapped[str] = mapped_column(String(255), nullable=False)

--- a/retriever/repository/document_repository.py
+++ b/retriever/repository/document_repository.py
@@ -1,4 +1,4 @@
-from sqlalchemy import select
+from sqlalchemy import literal_column, select
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import sessionmaker
 from typing import List
@@ -42,4 +42,35 @@ class DocumentRepository:
             session.refresh(doc) # To ensure the document is committed and has an ID
         return doc
 
-            
+    def search_by_vector(
+        self,
+        query_embedding: List[float],
+        domain: str,
+        top_k: int = 5,
+    ) -> List[dict]:
+        """
+        pgvector ORM: cosine_distance(<=>) 계산 후 상위 top_k 반환.
+        Returns [{rank, document, document_id, title, domain, score}, ...]
+        """
+        distance = Document.embedding.cosine_distance(query_embedding)
+        score_expr = (literal_column("1") - distance).label("score")
+        with self._session_factory() as session:
+            stmt = (
+                select(Document, score_expr)
+                .where(Document.domain == domain)
+                .where(Document.embedding.isnot(None))
+                .order_by(distance)
+                .limit(top_k)
+            )
+            rows = session.execute(stmt).all()
+        return [
+            {
+                "rank": i + 1,
+                "document": doc.content,
+                "document_id": str(doc.id),
+                "title": doc.title,
+                "domain": doc.domain,
+                "score": float(score),
+            }
+            for i, (doc, score) in enumerate(rows)
+        ]

--- a/retriever/repository/document_repository.py
+++ b/retriever/repository/document_repository.py
@@ -5,6 +5,7 @@ from typing import List
 
 from models import Document
 
+
 class DocumentRepository:
     def __init__(self, engine: Engine):
         self._session_factory = sessionmaker(autocommit=False, autoflush=False, bind=engine)
@@ -18,3 +19,27 @@ class DocumentRepository:
         with self._session_factory() as session:
             stmt = select(Document)
             return list(session.execute(stmt).scalars().all())
+
+    def add_document(
+        self,
+        title: str,
+        content: str,
+        domain: str,
+        embedding: List[float],
+        source_url: str | None = None,
+    ) -> Document:
+        """Insert a document with precomputed embedding."""
+        doc = Document(
+            title=title,
+            content=content,
+            domain=domain,
+            source_url=source_url,
+            embedding=embedding,
+        )
+        with self._session_factory() as session:
+            session.add(doc)
+            session.commit()
+            session.refresh(doc) # To ensure the document is committed and has an ID
+        return doc
+
+            

--- a/retriever/requirements.txt
+++ b/retriever/requirements.txt
@@ -1,5 +1,6 @@
 annotated-doc==0.0.3
 psycopg2-binary>=2.9.9
+pgvector>=0.2.0
 python-dotenv>=1.0.0
 sqlalchemy>=2.0.0
 annotated-types==0.7.0

--- a/retriever/retriever.py
+++ b/retriever/retriever.py
@@ -40,7 +40,7 @@ class SimpleRetriever:
         """1) content를 model로 임베딩, 2) repository.add_document로 저장."""
         embedding = self.model.encode(
             [content], convert_to_numpy=True, normalize_embeddings=True
-        ).tolist()[0]  # (1, 384) -> [float, ...]
+        ).tolist()[0] 
         return self.repository.add_document(
             title=title,
             content=content,

--- a/retriever/retriever.py
+++ b/retriever/retriever.py
@@ -18,17 +18,6 @@ class SimpleRetriever:
         self.repository = document_repository
         self.domain = domain
         self.model = SentenceTransformer(model_name)
-        self.documents: List[Document] = []
-        self.embeddings = None
-        self.index = None
-        self._load_data()
-        self._embed_documents()
-
-    def _load_data(self) -> None:
-        # Load documents from PostgreSQL based on the domain (for now)
-        # TODO: Load documents based on the domain received from orchestrator
-        self.documents = self.repository.get_documents(self.domain)
-        print(f"Loaded {len(self.documents)} documents from PostgreSQL (domain={self.domain}).")
 
     def add_document(
         self,
@@ -49,41 +38,13 @@ class SimpleRetriever:
             source_url=source_url,
         )
 
-    def _embed_documents(self) -> None:
-        if not self.documents:
-            print("No documents to embed.")
-            self.embeddings = None
-            self.index = None
-            return
-        contents = [doc.content for doc in self.documents]
-        self.embeddings = self.model.encode(
-            contents,
-            convert_to_numpy=True,
-            show_progress_bar=True,
-            normalize_embeddings=True,
-        )
-        dimension = self.embeddings.shape[1]
-        self.index = faiss.IndexFlatIP(dimension)
-        self.index.add(self.embeddings.astype("float32"))
-        print(f"Indexed {len(self.documents)} documents.")
-
     def query(self, query_text: str, top_k: int = 5) -> List[dict]:
-        if self.index is None or len(self.documents) == 0:
-            return []
+        """" Encode the query text and search the repository."""
         query_embedding = self.model.encode(
             [query_text], convert_to_numpy=True, normalize_embeddings=True
-        ).astype("float32")
-        distances, indices = self.index.search(query_embedding, top_k)
-        results = []
-        for i, idx in enumerate(indices[0]):
-            doc = self.documents[idx]
-            print(f"Document: {doc.id} (Score: {float(distances[0][i])})")
-            results.append({
-                "rank": i + 1,
-                "document": doc.content,
-                "document_id": doc.id,
-                "title": doc.title,
-                "domain": doc.domain,
-                "score": float(distances[0][i]),
-            })
+        ).tolist()[0]
+        results = self.repository.search_by_vector(query_embedding, self.domain, top_k)
+        print(f"Retrieved {len(results)} documents.")
+        for result in results:
+            print(f"Document: {result['title']} (Score: {result['score']})")
         return results

--- a/retriever/retriever.py
+++ b/retriever/retriever.py
@@ -30,6 +30,25 @@ class SimpleRetriever:
         self.documents = self.repository.get_documents(self.domain)
         print(f"Loaded {len(self.documents)} documents from PostgreSQL (domain={self.domain}).")
 
+    def add_document(
+        self,
+        title: str,
+        content: str,
+        domain: str,
+        source_url: str | None = None,
+    ) -> Document:
+        """1) content를 model로 임베딩, 2) repository.add_document로 저장."""
+        embedding = self.model.encode(
+            [content], convert_to_numpy=True, normalize_embeddings=True
+        ).tolist()[0]  # (1, 384) -> [float, ...]
+        return self.repository.add_document(
+            title=title,
+            content=content,
+            domain=domain,
+            embedding=embedding,
+            source_url=source_url,
+        )
+
     def _embed_documents(self) -> None:
         if not self.documents:
             print("No documents to embed.")


### PR DESCRIPTION
## 🧠 Summary
> Explain what this PR does.

This PR transitions the retrieval infrastructure from a stateful, in-memory FAISS-based system to a stateless, database-native vector search using pgvector on PostgreSQL.

## 🧩 Related Issues
Closes #38 

## 🧰 Changes
- [x] Feature / Improvement
- [ ] Bug Fix
- [ ] Test (Unit / Integration)
- [x] Refactor / Cleanup
- [ ] Documentation

## 🧪 Development Notes
> Use this section to help reviewers understand the implementation.  

1. Database-Native Vector Search
We have replaced the postgres:15.1-alpine image with pgvector/pgvector:pg15. The system now leverages the <=> (Cosine Distance) operator directly within PostgreSQL, ensuring that the Source of Truth (original text) and the Search Index (vectors) reside in the same ACID-compliant storage.

2. HNSW indexing
To guarantee sub-second latency for large-scale datasets, an HNSW index has been implemented.
-> Index Type: vector_cosine_ops

3. Stateless Retriever Design
The SimpleRetriever class has been refactored to remove all in-memory cache and indexing logic (_load_data, _embed_documents)
- Reduces the total pod memory usage of the retriever as the FAISS index is no longer loaded into application RAM
- Cold start: Eliminated startup latency previously caused by re-embedding and re-indexing the entire dataset on boot.


## 🔍 Testing
> Describe how you tested the change.

Integration Testing
- Document Ingestion: Verified via POST /add-document. Confirmed that embeddings are correctly generated by all-MiniLM-L6-v2 and stored in the embedding column.
- Similarity Search: Verified via POST /query. Confirmed that the HNSW index is utilized by checking the retriever score

## 🚀 Deployment Notes
> Any special considerations for deployment 